### PR TITLE
Cleanup subscriber on onStreamDropped

### DIFF
--- a/android/src/main/java/com/rnopentok/RNOpenTokSubscriberView.java
+++ b/android/src/main/java/com/rnopentok/RNOpenTokSubscriberView.java
@@ -81,6 +81,7 @@ public class RNOpenTokSubscriberView extends RNOpenTokView implements Subscriber
 
     public void onStreamDropped(Session session, Stream stream) {
         sendEvent(Events.EVENT_SUBSCRIBE_STOP, Arguments.createMap());
+        cleanUpSubscriber();
     }
 
     /** Subscribe listener **/


### PR DESCRIPTION
Changes:
- Run `cleanUpSubscriber` method on `onStreamDropped` event